### PR TITLE
Add csv export option for excel

### DIFF
--- a/src/main/java/software/latic/PrimaryViewModel.java
+++ b/src/main/java/software/latic/PrimaryViewModel.java
@@ -190,7 +190,8 @@ public class PrimaryViewModel implements Initializable {
         fileChooser.setInitialFileName("table");
         fileChooser.getExtensionFilters().addAll(
                 new FileChooser.ExtensionFilter("Text file", "*.txt"),
-                new FileChooser.ExtensionFilter("CSV table file", "*.csv"));
+                new FileChooser.ExtensionFilter("CSV table file", "*.csv"),
+                new FileChooser.ExtensionFilter("CSV table file for excel", "*.csv"));
 
     }
 
@@ -225,7 +226,9 @@ public class PrimaryViewModel implements Initializable {
         try {
             File file = fileChooser.showSaveDialog(stage);
             if (file != null) {
-                file = csvBuilder.writeToFile(file, getTableData());
+                file = fileChooser.getSelectedExtensionFilter().getDescription().contains("excel")
+                        ? csvBuilder.writeCsvForExcel(file, getTableData())
+                        : csvBuilder.writeToFile(file, getTableData());
                 fileChooser.setInitialDirectory(file.getParentFile());
             }
         } catch (IOException e) {

--- a/src/main/java/software/latic/helper/CsvBuilder.java
+++ b/src/main/java/software/latic/helper/CsvBuilder.java
@@ -25,6 +25,17 @@ public class CsvBuilder {
         return escapedData;
     }
 
+    public File writeCsvForExcel(File file, List<String[]> dataLines) throws IOException {
+        File csvOutputFile = new File(file.getPath());
+        try (PrintWriter pw = new PrintWriter(file)) {
+            pw.println(String.format("sep=%s", DEFAULT_SEPARATOR));
+            for (String[] data : dataLines) {
+                String x = convertToCSV(data);
+                pw.println(x);
+            }
+        }
+        return csvOutputFile;
+    }
 
     public File writeToFile(File file, List<String[]> dataLines) throws IOException {
         File csvOutputFile = new File(file.getPath());


### PR DESCRIPTION
Changing the default separator in excel isn't that easy. Therefore I've added a temporary "csv table file for excel" option that gives excel a hint on which separator to use.