### PR TITLE
Add support for passive voice analysis

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="MavenProjectsManager">
     <option name="originalFiles">
       <list>
@@ -7,5 +8,5 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_22" default="true" project-jdk-name="zulu-22" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_24" project-jdk-name="zulu-24 (2)" project-jdk-type="JavaSDK" />
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,17 +4,17 @@
 
     <groupId>software.latic</groupId>
     <artifactId>latic</artifactId>
-    <version>1.4.1</version>
+    <version>1.5.0</version>
     <packaging>jar</packaging>
 
     <name>LATIC</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>23</maven.compiler.source>
-        <maven.compiler.target>23</maven.compiler.target>
-        <maven.compiler.release>23</maven.compiler.release>
-        <javafx.version>23</javafx.version>
+        <maven.compiler.source>24</maven.compiler.source>
+        <maven.compiler.target>24</maven.compiler.target>
+        <maven.compiler.release>24</maven.compiler.release>
+        <javafx.version>24</javafx.version>
         <corenlp.version>[4.5.6,4.6.0)</corenlp.version>
         <com.ibm.icu.version>[68.1,69)</com.ibm.icu.version>
     </properties>

--- a/src/main/java/software/latic/PrimaryViewModel.java
+++ b/src/main/java/software/latic/PrimaryViewModel.java
@@ -306,21 +306,21 @@ public class PrimaryViewModel implements Initializable {
 
 
         generalTaskCheckBoxItems = FXCollections.observableArrayList(Arrays.stream(GeneralItemCharacteristics.values())
-                .map(textInformation -> new CheckBoxTreeItem<Task>(new Task(Translation.getInstance().getTranslation(textInformation.getId()), textInformation.getId(), textInformation.getLevel()), null, true))
+                .map(textInformation -> new CheckBoxTreeItem<Task>(new Task(Translation.getInstance().getTranslation(textInformation.getId()), textInformation.getId(), textInformation.getLevel()).setResultType(textInformation.getValueClass().orElse(null)), null, true))
                 .collect(Collectors.toList()));
 
         if (Translation.getInstance().canAnalyzeSyllablesForLocale()) {
             generalTaskCheckBoxItems.addAll(FXCollections.observableArrayList(Arrays.stream(SyllableItemCharacteristics.values())
-                    .map(textInformation -> new CheckBoxTreeItem<Task>(new Task(Translation.getInstance().getTranslation(textInformation.getId()), textInformation.getId(), textInformation.getLevel()), null, true))
+                    .map(textInformation -> new CheckBoxTreeItem<Task>(new Task(Translation.getInstance().getTranslation(textInformation.getId()), textInformation.getId(), textInformation.getLevel()).setResultType(textInformation.getValueClass().orElse(null)), null, true))
                     .collect(Collectors.toList())));
         }
 
         textTaskCheckBoxItems = FXCollections.observableArrayList(Arrays.stream(TextInformationItemCharacteristics.values())
-                .map(textInformationItemCharacteristics -> new CheckBoxTreeItem<Task>(new Task(Translation.getInstance().getTranslation(textInformationItemCharacteristics.getId()), textInformationItemCharacteristics.getId(), textInformationItemCharacteristics.getLevel()), null, true))
+                .map(textInformationItemCharacteristics -> new CheckBoxTreeItem<Task>(new Task(Translation.getInstance().getTranslation(textInformationItemCharacteristics.getId()), textInformationItemCharacteristics.getId(), textInformationItemCharacteristics.getLevel()).setResultType(textInformationItemCharacteristics.getValueClass().orElse(null)), null, true))
                 .collect(Collectors.toList()));
 
         languageSpecificTaskCheckBoxItems = FXCollections.observableArrayList(Arrays.stream(GeneralLanguageItemCharacteristics.values())
-                .map(generalLanguageItemCharacteristics -> new CheckBoxTreeItem<Task>(new Task(Translation.getInstance().getTranslation(generalLanguageItemCharacteristics.getId()), generalLanguageItemCharacteristics.getId(), generalLanguageItemCharacteristics.getLevel()), null, true))
+                .map(generalLanguageItemCharacteristics -> new CheckBoxTreeItem<Task>(new Task(Translation.getInstance().getTranslation(generalLanguageItemCharacteristics.getId()), generalLanguageItemCharacteristics.getId(), generalLanguageItemCharacteristics.getLevel()).setResultType(generalLanguageItemCharacteristics.getValueClass().orElse(null)), null, true))
                 .collect(Collectors.toList()));
 
         if (choiceBoxLanguage.getValue().equals(Locale.ENGLISH)) {
@@ -329,9 +329,9 @@ public class PrimaryViewModel implements Initializable {
                             .map(ic -> new CheckBoxTreeItem<Task>(
                                     new Task(Translation.getInstance().getTranslation(ic.getId()),
                                             ic.getId(),
-                                            ic.getLevel(),
-                                            ic.getIsBeta()
-                                    ), null, true))
+                                            ic.getLevel()
+                                    ).setIsBeta(ic.getIsBeta()).setResultType(ic.getValueClass().orElse(null))
+                                    , null, true))
                             .collect(Collectors.toList())
             ));
             languageSpecificTaskCheckBoxItems.addAll(FXCollections.observableArrayList(
@@ -340,7 +340,7 @@ public class PrimaryViewModel implements Initializable {
                                     new Task(Translation.getInstance().getTranslation(ic.getId()),
                                             ic.getId(),
                                             ic.getLevel()
-                                    ), null, true))
+                                    ).setResultType(ic.getValueClass().orElse(null)), null, true))
                             .collect(Collectors.toList())
             ));
         }
@@ -351,9 +351,8 @@ public class PrimaryViewModel implements Initializable {
                             .map(ic -> new CheckBoxTreeItem<Task>(
                                     new Task(Translation.getInstance().getTranslation(ic.getId()),
                                             ic.getId(),
-                                            ic.getLevel(),
-                                            ic.getIsBeta()
-                                    ), null, true))
+                                            ic.getLevel()
+                                    ).setIsBeta(ic.getIsBeta()).setResultType(ic.getValueClass().orElse(null)), null, true))
                             .collect(Collectors.toList())
             ));
             languageSpecificTaskCheckBoxItems.addAll(FXCollections.observableArrayList(
@@ -362,7 +361,7 @@ public class PrimaryViewModel implements Initializable {
                                     new Task(Translation.getInstance().getTranslation(ic.getId()),
                                             ic.getId(),
                                             ic.getLevel()
-                                    ), null, true))
+                                    ).setResultType(ic.getValueClass().orElse(null)), null, true))
                             .collect(Collectors.toList())
             ));
         }

--- a/src/main/java/software/latic/item/EnglishGeneralItemCharacteristics.java
+++ b/src/main/java/software/latic/item/EnglishGeneralItemCharacteristics.java
@@ -2,6 +2,8 @@ package software.latic.item;
 
 import software.latic.task.TaskLevel;
 
+import java.util.Optional;
+
 public enum EnglishGeneralItemCharacteristics implements ItemCharacteristics {
     FLESCH_INDEX( "fleschIndexEnglish", TaskLevel.TEXT_READABILITY),
     FLESCH_INDEX_LEVEL( "fleschIndexEnglishLevel", TaskLevel.TEXT_READABILITY),
@@ -35,15 +37,25 @@ public enum EnglishGeneralItemCharacteristics implements ItemCharacteristics {
 
     public boolean getIsBeta() {return isBeta;}
 
-    EnglishGeneralItemCharacteristics(String id, TaskLevel level, boolean isBeta) {
+    private final Class<?> valueClass;
+
+    @Override
+    public Optional<Class<?>> getValueClass() {
+        return Optional.ofNullable(valueClass);
+    }
+
+    EnglishGeneralItemCharacteristics(String id, TaskLevel level, boolean isBeta, Class<?> valueClass) {
         this.id = id;
         this.level = level;
         this.isBeta = isBeta;
+        this.valueClass = valueClass;
+    }
+
+    EnglishGeneralItemCharacteristics(String id, TaskLevel level, boolean isBeta) {
+        this( id, level, isBeta, null);
     }
 
     EnglishGeneralItemCharacteristics(String id, TaskLevel level) {
-        this.id = id;
-        this.level = level;
-        this.isBeta = false;
+        this( id, level, false);
     }
 }

--- a/src/main/java/software/latic/item/EnglishItemCharacteristics.java
+++ b/src/main/java/software/latic/item/EnglishItemCharacteristics.java
@@ -2,6 +2,8 @@ package software.latic.item;
 
 import software.latic.task.TaskLevel;
 
+import java.util.Optional;
+
 public enum EnglishItemCharacteristics implements ItemCharacteristics {
     CONJUNCTIONS("conjunctions", TaskLevel.WORD_CLASS),
     EXISTENTIAL_THERE("existentialThere", TaskLevel.WORD_CLASS),
@@ -23,15 +25,26 @@ public enum EnglishItemCharacteristics implements ItemCharacteristics {
     private final TaskLevel level;
 
     public TaskLevel getLevel() { return level; }
+    
+    private final Class<?> valueClass;
+    
+    @Override
+    public Optional<Class<?>> getValueClass() {
+        return Optional.ofNullable(valueClass);
+    }
 
-    EnglishItemCharacteristics(String id, TaskLevel level) {
+    EnglishItemCharacteristics(String id, TaskLevel level, Class<?> valueClass) {
         this.id = id;
         this.level = level;
+        this.valueClass = valueClass;
+    }
+
+    EnglishItemCharacteristics(String id, TaskLevel level) {
+        this(id, level, null);
     }
 
     EnglishItemCharacteristics(String id) {
-        this.id = id;
-        this.level = TaskLevel.WORD;
+        this(id, TaskLevel.WORD);
     }
 
 }

--- a/src/main/java/software/latic/item/GeneralItemCharacteristics.java
+++ b/src/main/java/software/latic/item/GeneralItemCharacteristics.java
@@ -2,6 +2,8 @@ package software.latic.item;
 
 import software.latic.task.TaskLevel;
 
+import java.util.Optional;
+
 public enum GeneralItemCharacteristics implements ItemCharacteristics {
 
     WORD_COUNT("wordCount", TaskLevel.TEXT),
@@ -25,10 +27,22 @@ public enum GeneralItemCharacteristics implements ItemCharacteristics {
     public String getId() {
         return id;
     }
+    
+    private final Class<?> valueClass;
+    
+    @Override
+    public Optional<Class<?>> getValueClass() {
+        return Optional.ofNullable(valueClass);
+    }
 
-    GeneralItemCharacteristics(String id, TaskLevel level) {
+    GeneralItemCharacteristics(String id, TaskLevel level, Class<?> valueClass) {
         this.id = id;
         this.level = level;
+        this.valueClass = valueClass;
+    }
+    
+    GeneralItemCharacteristics(String id, TaskLevel level) {
+        this(id, level, null);
     }
 
 }

--- a/src/main/java/software/latic/item/GeneralLanguageItemCharacteristics.java
+++ b/src/main/java/software/latic/item/GeneralLanguageItemCharacteristics.java
@@ -2,6 +2,8 @@ package software.latic.item;
 
 import software.latic.task.TaskLevel;
 
+import java.util.Optional;
+
 public enum GeneralLanguageItemCharacteristics implements ItemCharacteristics {
 
 
@@ -31,14 +33,25 @@ public enum GeneralLanguageItemCharacteristics implements ItemCharacteristics {
     public String getId() {
         return id;
     }
+    
+    private final Class<?> valueClass;
+    
+    @Override
+    public Optional<Class<?>> getValueClass() {
+        return Optional.ofNullable(valueClass);
+    }
 
-    GeneralLanguageItemCharacteristics(String id, TaskLevel level) {
+    GeneralLanguageItemCharacteristics(String id, TaskLevel level, Class<?> valueClass) {
         this.id = id;
         this.level = level;
+        this.valueClass = valueClass;
+    }
+
+    GeneralLanguageItemCharacteristics(String id, TaskLevel level) {
+        this(id, level, null);
     }
 
     GeneralLanguageItemCharacteristics(String id) {
-        this.id = id;
-        this.level = TaskLevel.WORD;
+        this(id, TaskLevel.WORD);
     }
 }

--- a/src/main/java/software/latic/item/GermanGeneralItemCharacteristics.java
+++ b/src/main/java/software/latic/item/GermanGeneralItemCharacteristics.java
@@ -2,6 +2,8 @@ package software.latic.item;
 
 import software.latic.task.TaskLevel;
 
+import java.util.Optional;
+
 public enum GermanGeneralItemCharacteristics implements ItemCharacteristics {
     FLESCH_INDEX( "fleschIndexGerman", TaskLevel.TEXT_READABILITY),
     FLESCH_INDEX_LEVEL( "fleschIndexGermanLevel", TaskLevel.TEXT_READABILITY),
@@ -29,16 +31,26 @@ public enum GermanGeneralItemCharacteristics implements ItemCharacteristics {
     public final boolean isBeta;
 
     public boolean getIsBeta() {return isBeta;}
+    
+    private final Class<?> valueClass;
+    
+    @Override
+    public Optional<Class<?>> getValueClass() {
+        return Optional.ofNullable(valueClass);
+    }
 
-    GermanGeneralItemCharacteristics(String id, TaskLevel level, boolean isBeta) {
+    GermanGeneralItemCharacteristics(String id, TaskLevel level, boolean isBeta, Class<?> valueClass) {
         this.id = id;
         this.level = level;
         this.isBeta = isBeta;
+        this.valueClass = valueClass;
+    }
+
+    GermanGeneralItemCharacteristics(String id, TaskLevel level, boolean isBeta) {
+        this(id, level, isBeta, null);
     }
 
     GermanGeneralItemCharacteristics(String id, TaskLevel level) {
-        this.id = id;
-        this.level = level;
-        this.isBeta = false;
+        this(id, level, false);
     }
 }

--- a/src/main/java/software/latic/item/GermanItemCharacteristics.java
+++ b/src/main/java/software/latic/item/GermanItemCharacteristics.java
@@ -2,6 +2,8 @@ package software.latic.item;
 
 import software.latic.task.TaskLevel;
 
+import java.util.Optional;
+
 public enum GermanItemCharacteristics implements ItemCharacteristics {
     ADPOSITIONS( "adpositions", TaskLevel.WORD_CLASS),
     COORDINATING_CONJUNCTIONS("coordinatingConjunctions", TaskLevel.WORD_CLASS),
@@ -18,15 +20,25 @@ public enum GermanItemCharacteristics implements ItemCharacteristics {
     public String getId() {
         return id;
     }
+    
+    private final Class<?> valueClass;
+    
+    @Override
+    public Optional<Class<?>> getValueClass() {
+        return Optional.ofNullable(valueClass);
+    }
 
-
-    GermanItemCharacteristics(String id, TaskLevel level) {
+    GermanItemCharacteristics(String id, TaskLevel level, Class<?> valueClass) {
         this.id = id;
         this.level = level;
+        this.valueClass = valueClass;
+    }
+
+    GermanItemCharacteristics(String id, TaskLevel level) {
+        this(id, level, null);
     }
 
     GermanItemCharacteristics(String id) {
-        this.id = id;
-        this.level = TaskLevel.WORD;
+        this(id, TaskLevel.WORD);
     }
 }

--- a/src/main/java/software/latic/item/ItemCharacteristics.java
+++ b/src/main/java/software/latic/item/ItemCharacteristics.java
@@ -2,8 +2,11 @@ package software.latic.item;
 
 import software.latic.task.TaskLevel;
 
+import java.util.Optional;
+
 public interface ItemCharacteristics {
 
     String getId();
     TaskLevel getLevel();
+    Optional<Class<?>> getValueClass();
 }

--- a/src/main/java/software/latic/item/SyllableItemCharacteristics.java
+++ b/src/main/java/software/latic/item/SyllableItemCharacteristics.java
@@ -2,6 +2,8 @@ package software.latic.item;
 
 import software.latic.task.TaskLevel;
 
+import java.util.Optional;
+
 public enum SyllableItemCharacteristics implements ItemCharacteristics {
 
     SYLLABLE_COUNT("syllableCount", TaskLevel.TEXT),
@@ -20,10 +22,22 @@ public enum SyllableItemCharacteristics implements ItemCharacteristics {
     public String getId() {
         return id;
     }
+    
+    private final Class<?> valueClass;
+    
+    @Override
+    public Optional<Class<?>> getValueClass() {
+        return Optional.ofNullable(valueClass);
+    }
 
-    SyllableItemCharacteristics(String id, TaskLevel level) {
+    SyllableItemCharacteristics(String id, TaskLevel level, Class<?> valueClass) {
         this.id = id;
         this.level = level;
+        this.valueClass = valueClass;
+    }
+    
+    SyllableItemCharacteristics(String id, TaskLevel level) {
+        this(id, level, null);
     }
 
 }

--- a/src/main/java/software/latic/item/TextInformationItemCharacteristics.java
+++ b/src/main/java/software/latic/item/TextInformationItemCharacteristics.java
@@ -2,8 +2,11 @@ package software.latic.item;
 
 import software.latic.task.TaskLevel;
 
+import java.util.Optional;
+
 public enum TextInformationItemCharacteristics implements ItemCharacteristics {
-    TEXT_AND_POS_TAGS("textAndPosTags", TaskLevel.TEXT);
+    TEXT_AND_POS_TAGS("textAndPosTags", TaskLevel.TEXT, String.class),
+    PASSIVE_CONSTRUCTIONS_COUNT("passiveConstructionsCount", TaskLevel.TEXT, Integer.class),;
 //    POS_TAGS_PER_SENTENCE("posTagsPerSentence", TaskLevel.TEXT);
 
 
@@ -14,14 +17,25 @@ public enum TextInformationItemCharacteristics implements ItemCharacteristics {
     private final TaskLevel level;
 
     public TaskLevel getLevel() { return level; }
+    
+    private final Class<?> valueClass;
+    
+    @Override
+    public Optional<Class<?>> getValueClass() {
+        return Optional.ofNullable(valueClass);
+    }
 
-    TextInformationItemCharacteristics(String id, TaskLevel level) {
+    TextInformationItemCharacteristics(String id, TaskLevel level, Class<?> valueClass) {
         this.id = id;
         this.level = level;
+        this.valueClass = valueClass;
+    }
+
+    TextInformationItemCharacteristics(String id, TaskLevel level) {
+        this(id, level, null);
     }
 
     TextInformationItemCharacteristics(String id) {
-        this.id = id;
-        this.level = TaskLevel.WORD;
+        this(id, TaskLevel.WORD);
     }
 }

--- a/src/main/java/software/latic/item/TextItemData.java
+++ b/src/main/java/software/latic/item/TextItemData.java
@@ -13,6 +13,7 @@ public abstract class TextItemData {
     final StringProperty fileName;
     final StringProperty text;
     StringProperty textAndPosTags;
+    IntegerProperty passiveConstructionsCount;
     IntegerProperty wordCount;
     IntegerProperty sentenceCount;
     IntegerProperty syllableCount;
@@ -103,6 +104,7 @@ public abstract class TextItemData {
         this.fileName = new SimpleStringProperty();
         this.text = new SimpleStringProperty(text);
         this.textAndPosTags = new SimpleStringProperty();
+        this.passiveConstructionsCount = new SimpleIntegerProperty();
         this.wordCount = new SimpleIntegerProperty();
         this.sentenceCount = new SimpleIntegerProperty();
         this.syllableCount = new SimpleIntegerProperty();
@@ -124,6 +126,7 @@ public abstract class TextItemData {
         valueMap.put("fileName", getFileName());
         valueMap.put("text",getText());
         valueMap.put("textAndPosTags",getTextAndPosTags());
+        valueMap.put("passiveConstructionsCount", String.valueOf(getPassiveConstructionsCount()));
         valueMap.put("wordCount",String.valueOf(getWordCount()));
         valueMap.put("sentenceCount",String.valueOf(getSentenceCount()));
         valueMap.put("syllableCount",String.valueOf(getSyllableCount()));
@@ -328,5 +331,17 @@ public abstract class TextItemData {
 
     public void setLixReadabilityLevel(String lixReadabilityLevel) {
         this.lixReadabilityLevel.set(lixReadabilityLevel);
+    }
+
+    public Integer getPassiveConstructionsCount() {
+        return passiveConstructionsCount.get();
+    }
+
+    public IntegerProperty passiveConstructionsCountProperty() {
+        return passiveConstructionsCount;
+    }
+
+    public void setPassiveConstructionsCount(Integer passiveConstructionsCount) {
+        this.passiveConstructionsCount.set(passiveConstructionsCount);
     }
 }

--- a/src/main/java/software/latic/task/Task.java
+++ b/src/main/java/software/latic/task/Task.java
@@ -6,19 +6,22 @@ import javafx.beans.property.ReadOnlyStringProperty;
 import javafx.beans.property.ReadOnlyStringWrapper;
 import javafx.beans.property.SimpleBooleanProperty;
 
+import java.util.Optional;
+
 public class Task {
     private ReadOnlyStringWrapper name = new ReadOnlyStringWrapper();
     private ReadOnlyStringWrapper id = new ReadOnlyStringWrapper();
     private BooleanProperty selected = new SimpleBooleanProperty(false);
     private TaskLevel level;
     private boolean isBeta = false;
+    private Class<?>  resultType = null;
 
     public Task(TaskLevel taskLevel) {
         this.name.set(Translation.getInstance().getTranslation(taskLevel.name()));
         this.id.set(taskLevel.name());
         this.level = taskLevel;
 
-        setSelected(true);
+        this.selected.set(true);
     }
 
     public Task(String name, String id, TaskLevel taskLevel) {
@@ -26,16 +29,7 @@ public class Task {
         this.id.set(id);
         this.level = taskLevel;
 
-        setSelected(true);
-    }
-
-    public Task(String name, String id, TaskLevel taskLevel, boolean isBeta) {
-        this.name.set(name);
-        this.id.set(id);
-        this.level = taskLevel;
-        this.isBeta = isBeta;
-
-        setSelected(true);
+        this.selected.set(true);
     }
 
     public String getId() {
@@ -61,7 +55,10 @@ public class Task {
     public TaskLevel getLevel() {return this.level;}
 
     public boolean getIsBeta() {return this.isBeta;}
-    public void setIsBeta(boolean isBeta) {this.isBeta = isBeta;}
+    public Task setIsBeta(boolean isBeta) {
+        this.isBeta = isBeta;
+        return this;
+    }
 
     public BooleanProperty selectedProperty() {
         return selected;
@@ -69,11 +66,22 @@ public class Task {
     public boolean isSelected() {
         return selected.get();
     }
-    public void setSelected(boolean selected) {
+    public Task setSelected(boolean selected) {
         this.selected.set(selected);
+        return this;
     }
 
     public boolean equals(Task task) {
         return this.id.equals(task.id);
     }
+
+    public Optional<Class<?>> getResultType() {
+        return Optional.ofNullable(resultType);
+    }
+
+    public Task setResultType(Class<?> resultType) {
+        this.resultType = resultType;
+        return this;
+    }
+
 }

--- a/src/main/java/software/latic/text_analyzer/NlpTextAnalyzer.java
+++ b/src/main/java/software/latic/text_analyzer/NlpTextAnalyzer.java
@@ -11,6 +11,11 @@ import javafx.collections.ObservableList;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 public class NlpTextAnalyzer extends BaseTextAnalyzer implements TextAnalyzer {
 
@@ -23,6 +28,8 @@ public class NlpTextAnalyzer extends BaseTextAnalyzer implements TextAnalyzer {
     private NlpTextAnalyzer() {
     }
 
+    //TODO only parse sentence once and save data
+
     public String textAndPosTags() {
         StringBuilder sb = new StringBuilder();
         doc.sentences().forEach(sentence -> {
@@ -34,6 +41,69 @@ public class NlpTextAnalyzer extends BaseTextAnalyzer implements TextAnalyzer {
             sb.append("\n");
         });
         return sb.toString().trim();
+    }
+
+    public Integer passiveConstructionsCount() {
+        AtomicInteger count = new AtomicInteger(0);
+
+        doc.sentences().forEach(sentence -> {
+            var labels = sentence.incomingDependencyLabels().stream()
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .collect(Collectors.toList());
+
+            int pairsInSentence = (int) Math.min(
+                    labels.stream().filter("nsubj:pass"::equals).count(),
+                    labels.stream().filter("aux:pass"::equals).count()
+            );
+
+            count.addAndGet(pairsInSentence);
+
+            Logger.getLogger("NlpTextAnalyzer").log(Level.INFO,
+                    String.format("sentence: %s", sentence.text()));
+            Logger.getLogger("NlpTextAnalyzer").log(Level.INFO,
+                    String.format("pairs in sentence: %d", pairsInSentence));
+        });
+
+        Logger.getLogger("NlpTextAnalyzer").log(Level.INFO,
+                String.format("Total passive construction pairs: %d", count.get()));
+        return count.get();
+
+    }
+
+    public String passiveConstructions() {
+        StringBuilder sb = new StringBuilder();
+        AtomicInteger count = new AtomicInteger(0);
+
+        doc.sentences().forEach(sentence -> {
+            var labels = sentence.incomingDependencyLabels().stream()
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .collect(Collectors.toList());
+
+            int pairsInSentence = (int) Math.min(
+                    labels.stream().filter("nsubj:pass"::equals).count(),
+                    labels.stream().filter("aux:pass"::equals).count()
+            );
+
+            count.addAndGet(pairsInSentence);
+
+            sentence.incomingDependencyLabels().forEach(label -> {
+                label.ifPresent(l -> sb.append(l).append(" "));
+            });
+            sb.append("\n");
+
+            Logger.getLogger("NlpTextAnalyzer").log(Level.INFO,
+                    String.format("sentence: %s", sentence.text()));
+            Logger.getLogger("NlpTextAnalyzer").log(Level.INFO,
+                    String.format("pairs in sentence: %d", pairsInSentence));
+        });
+
+        var result = sb.toString().trim();
+        Logger.getLogger("NlpTextAnalyzer").log(Level.INFO,
+                String.format("Total passive construction pairs: %d", count.get()));
+        return result.isEmpty() ? "" : result;
+
     }
 
     private List<String> replaceTags(List<Token> tokens) {
@@ -63,10 +133,12 @@ public class NlpTextAnalyzer extends BaseTextAnalyzer implements TextAnalyzer {
                     var setterName = task.getId();
                     setterName = setterName.substring(0, 1).toUpperCase() + setterName.substring(1);
                     setterName = "set" + setterName;
-                    setter = textItemData.getClass().getMethod(setterName, String.class);
 
+                    var resultClass = task.getResultType().orElse(String.class);
 
-                    setter.invoke(textItemData, String.valueOf(nlpMethod.invoke(this)));
+                    setter = textItemData.getClass().getMethod(setterName, resultClass);
+
+                    setter.invoke(textItemData, nlpMethod.invoke(this));
 
                 } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
                     e.printStackTrace();

--- a/src/main/resources/software/latic/messages_de.properties
+++ b/src/main/resources/software/latic/messages_de.properties
@@ -28,6 +28,8 @@ averageSentenceLengthSyllables=Satzlänge (Silben)
 lexicalDiversity=Lexikvarianz
 lixReadabilityScore=LIX
 textAndPosTags=Annotierter Text / Annotiertes Item
+passiveConstructions=Passivkonstruktionen
+passiveConstructionsCount=Passivkonstruktionen
 posTagsPerSentence=Annotierte Sätze
 #General language tasks
 adjectives=Adjektive

--- a/src/main/resources/software/latic/messages_en.properties
+++ b/src/main/resources/software/latic/messages_en.properties
@@ -27,6 +27,8 @@ averageSentenceLengthSyllables=Sentence length (syllables)
 lexicalDiversity=Lexical diversity
 lixReadabilityScore=LIX
 textAndPosTags=Tagged text or item
+passiveConstructions=Passive constructions
+passiveConstructionsCount=Passive constructions
 posTagsPerSentence=Tagged sentences
 #General language tasks
 adjectives=Adjectives

--- a/src/test/java/software/latic/text_analyzer/NlpTextAnalyzerTest.java
+++ b/src/test/java/software/latic/text_analyzer/NlpTextAnalyzerTest.java
@@ -1,0 +1,186 @@
+package software.latic.text_analyzer;
+
+import edu.stanford.nlp.simple.Document;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class NlpTextAnalyzerTest {
+
+    @Test
+    void givenDocumentWithPassiveVoice_whenPassiveConstructionsCalled_thenCorrectDependenciesReturned() {
+        // Arrange
+        String text = "The book was read by the class.";
+        Document doc = new Document(text);
+        NlpTextAnalyzer analyzer = NlpTextAnalyzer.getInstance();
+        analyzer.setDoc(doc);
+
+        // Act
+        String result = analyzer.passiveConstructions();
+
+        // Assert
+        assertNotNull(result, "The result should not be null.");
+        assertTrue(result.contains("nsubj:pass"), "Expected 'nsubj:pass' dependency for passive voice.");
+        assertTrue(result.contains("aux:pass"), "Expected 'aux:pass' dependency for auxiliary passive.");
+        assertTrue(result.contains("obl"), "Expected 'obl' dependency to indicate 'by the class'.");
+    }
+
+    @Test
+    void givenDocumentWithoutPassiveVoice_whenPassiveConstructionsCalled_thenMinimalDependenciesReturned() {
+        // Arrange
+        String text = "The class reads the book.";
+        Document doc = new Document(text);
+        NlpTextAnalyzer analyzer = NlpTextAnalyzer.getInstance();
+        analyzer.setDoc(doc);
+
+        // Act
+        String result = analyzer.passiveConstructions();
+
+        // Assert
+        assertNotNull(result, "The result should not be null.");
+        assertFalse(result.contains("nsubj:pass"), "Result should not contain 'nsubj:pass'.");
+        assertFalse(result.contains("aux:pass"), "Result should not contain 'aux:pass'.");
+    }
+
+    @Test
+    void givenEmptyDocument_whenPassiveConstructionsCalled_thenEmptyStringReturned() {
+        // Arrange
+        String text = "";
+        Document doc = new Document(text);
+        NlpTextAnalyzer analyzer = NlpTextAnalyzer.getInstance();
+        analyzer.setDoc(doc);
+
+        // Act
+        String result = analyzer.passiveConstructions();
+
+        // Assert
+        assertNotNull(result, "The result should not be null.");
+        assertEquals("", result, "Expected an empty string for an empty document.");
+    }
+
+    @Test
+    void givenDocumentWithMultipleSentences_whenPassiveConstructionsCalled_thenDependenciesForAllSentencesReturned() {
+        // Arrange
+        String text = "The cake was baked by Alice. The cat chased the mouse.";
+        Document doc = new Document(text);
+        NlpTextAnalyzer analyzer = NlpTextAnalyzer.getInstance();
+        analyzer.setDoc(doc);
+
+        // Act
+        String result = analyzer.passiveConstructions();
+
+        // Assert
+        assertNotNull(result, "The result should not be null.");
+        assertTrue(result.contains("nsubj:pass"), "Expected 'nsubj:pass' for sentence with passive voice.");
+        assertTrue(result.contains("aux:pass"), "Expected 'aux:pass' for sentence with passive voice.");
+        assertTrue(result.contains("nsubj"), "Expected 'nsubj' for sentence without passive voice.");
+    }
+
+    @Test
+    void givenDocumentWithComplexConstructions_whenPassiveConstructionsCalled_thenCorrectDependenciesReturned() {
+        // Arrange
+        String text = "The homework was completed by the students, and the teacher was impressed.";
+        Document doc = new Document(text);
+        NlpTextAnalyzer analyzer = NlpTextAnalyzer.getInstance();
+        analyzer.setDoc(doc);
+
+        // Act
+        String result = analyzer.passiveConstructions();
+
+        // Assert
+        assertNotNull(result, "The result should not be null.");
+        assertTrue(result.contains("nsubj:pass"), "Expected 'nsubj:pass' for passive construction.");
+        assertTrue(result.contains("aux:pass"), "Expected 'auxp:ass' for passive auxiliary.");
+        assertTrue(result.contains("cc"), "Expected 'cc' for conjunction between clauses.");
+    }
+
+    @Test
+    void givenDocumentWithPassiveVoice_whenPassiveConstructionsCountCalled_thenCorrectCountReturned() {
+        // Arrange
+        String text = "The book was read by the boy.";
+        Document doc = new Document(text);
+        NlpTextAnalyzer analyzer = NlpTextAnalyzer.getInstance();
+        analyzer.setDoc(doc);
+
+        // Act
+        int result = analyzer.passiveConstructionsCount();
+
+        // Assert
+        assertEquals(1, result, "Expected 1 passive construction.");
+    }
+
+    @Test
+    void givenDocumentWithoutPassiveVoice_whenPassiveConstructionsCountCalled_thenZeroCountReturned() {
+        // Arrange
+        String text = "The boy reads the book.";
+        Document doc = new Document(text);
+        NlpTextAnalyzer analyzer = NlpTextAnalyzer.getInstance();
+        analyzer.setDoc(doc);
+
+        // Act
+        int result = analyzer.passiveConstructionsCount();
+
+        // Assert
+        assertEquals(0, result, "Expected 0 passive constructions.");
+    }
+
+    @Test
+    void givenEmptyDocument_whenPassiveConstructionsCountCalled_thenZeroCountReturned() {
+        // Arrange
+        String text = "";
+        Document doc = new Document(text);
+        NlpTextAnalyzer analyzer = NlpTextAnalyzer.getInstance();
+        analyzer.setDoc(doc);
+
+        // Act
+        int result = analyzer.passiveConstructionsCount();
+
+        // Assert
+        assertEquals(0, result, "Expected 0 passive constructions for an empty document.");
+    }
+
+    @Test
+    void givenDocumentWithMultiplePassiveVoiceSentences_whenPassiveConstructionsCountCalled_thenCorrectCountReturned() {
+        // Arrange
+        String text = "The cake was baked by Alice. The homework was completed by the students.";
+        Document doc = new Document(text);
+        NlpTextAnalyzer analyzer = NlpTextAnalyzer.getInstance();
+        analyzer.setDoc(doc);
+
+        // Act
+        int result = analyzer.passiveConstructionsCount();
+
+        // Assert
+        assertEquals(2, result, "Expected 2 passive constructions.");
+    }
+
+    @Test
+    void givenDocumentWithMultiplePassiveVoiceInOneSentence_whenPassiveConstructionsCountCalled_thenCorrectCountReturned() {
+        // Arrange
+        String text = "The report was written by the intern, and the presentation was prepared by the team.";
+        Document doc = new Document(text);
+        NlpTextAnalyzer analyzer = NlpTextAnalyzer.getInstance();
+        analyzer.setDoc(doc);
+
+        // Act
+        int result = analyzer.passiveConstructionsCount();
+
+        // Assert
+        assertEquals(2, result, "Expected 2 passive constructions.");
+    }
+
+    @Test
+    void givenDocumentWithComplexPassives_whenPassiveConstructionsCountCalled_thenCorrectCountReturned() {
+        // Arrange
+        String text = "The homework was completed by the students, and the teacher was impressed.";
+        Document doc = new Document(text);
+        NlpTextAnalyzer analyzer = NlpTextAnalyzer.getInstance();
+        analyzer.setDoc(doc);
+
+        // Act
+        int result = analyzer.passiveConstructionsCount();
+
+        // Assert
+        assertEquals(1, result, "Expected 1 passive construction despite the complex structure.");
+    }
+}


### PR DESCRIPTION
- Introduced methods `passiveConstructions` and `passiveConstructionsCount` in `NlpTextAnalyzer`.
- Added corresponding test cases in `NlpTextAnalyzerTest`.
- Extended `Task` and `ItemCharacteristics` to support result types.
- Updated UI and property files to provide identifiers for passive constructions analysis.
- Bumped Java version to 24 and project version to 1.5.0.