### PR TITLE
Refactoring: Revert resultTypes in ItemCharacteristics and Task to simplify logic

### DIFF
--- a/src/main/java/software/latic/PrimaryViewModel.java
+++ b/src/main/java/software/latic/PrimaryViewModel.java
@@ -306,21 +306,21 @@ public class PrimaryViewModel implements Initializable {
 
 
         generalTaskCheckBoxItems = FXCollections.observableArrayList(Arrays.stream(GeneralItemCharacteristics.values())
-                .map(textInformation -> new CheckBoxTreeItem<Task>(new Task(Translation.getInstance().getTranslation(textInformation.getId()), textInformation.getId(), textInformation.getLevel()).setResultType(textInformation.getValueClass().orElse(null)), null, true))
+                .map(textInformation -> new CheckBoxTreeItem<Task>(new Task(Translation.getInstance().getTranslation(textInformation.getId()), textInformation.getId(), textInformation.getLevel()), null, true))
                 .collect(Collectors.toList()));
 
         if (Translation.getInstance().canAnalyzeSyllablesForLocale()) {
             generalTaskCheckBoxItems.addAll(FXCollections.observableArrayList(Arrays.stream(SyllableItemCharacteristics.values())
-                    .map(textInformation -> new CheckBoxTreeItem<Task>(new Task(Translation.getInstance().getTranslation(textInformation.getId()), textInformation.getId(), textInformation.getLevel()).setResultType(textInformation.getValueClass().orElse(null)), null, true))
+                    .map(textInformation -> new CheckBoxTreeItem<Task>(new Task(Translation.getInstance().getTranslation(textInformation.getId()), textInformation.getId(), textInformation.getLevel()), null, true))
                     .collect(Collectors.toList())));
         }
 
         textTaskCheckBoxItems = FXCollections.observableArrayList(Arrays.stream(TextInformationItemCharacteristics.values())
-                .map(textInformationItemCharacteristics -> new CheckBoxTreeItem<Task>(new Task(Translation.getInstance().getTranslation(textInformationItemCharacteristics.getId()), textInformationItemCharacteristics.getId(), textInformationItemCharacteristics.getLevel()).setResultType(textInformationItemCharacteristics.getValueClass().orElse(null)), null, true))
+                .map(textInformationItemCharacteristics -> new CheckBoxTreeItem<Task>(new Task(Translation.getInstance().getTranslation(textInformationItemCharacteristics.getId()), textInformationItemCharacteristics.getId(), textInformationItemCharacteristics.getLevel()), null, true))
                 .collect(Collectors.toList()));
 
         languageSpecificTaskCheckBoxItems = FXCollections.observableArrayList(Arrays.stream(GeneralLanguageItemCharacteristics.values())
-                .map(generalLanguageItemCharacteristics -> new CheckBoxTreeItem<Task>(new Task(Translation.getInstance().getTranslation(generalLanguageItemCharacteristics.getId()), generalLanguageItemCharacteristics.getId(), generalLanguageItemCharacteristics.getLevel()).setResultType(generalLanguageItemCharacteristics.getValueClass().orElse(null)), null, true))
+                .map(generalLanguageItemCharacteristics -> new CheckBoxTreeItem<Task>(new Task(Translation.getInstance().getTranslation(generalLanguageItemCharacteristics.getId()), generalLanguageItemCharacteristics.getId(), generalLanguageItemCharacteristics.getLevel()), null, true))
                 .collect(Collectors.toList()));
 
         if (choiceBoxLanguage.getValue().equals(Locale.ENGLISH)) {
@@ -329,9 +329,9 @@ public class PrimaryViewModel implements Initializable {
                             .map(ic -> new CheckBoxTreeItem<Task>(
                                     new Task(Translation.getInstance().getTranslation(ic.getId()),
                                             ic.getId(),
-                                            ic.getLevel()
-                                    ).setIsBeta(ic.getIsBeta()).setResultType(ic.getValueClass().orElse(null))
-                                    , null, true))
+                                            ic.getLevel(),
+                                            ic.getIsBeta()
+                                    ), null, true))
                             .collect(Collectors.toList())
             ));
             languageSpecificTaskCheckBoxItems.addAll(FXCollections.observableArrayList(
@@ -340,7 +340,7 @@ public class PrimaryViewModel implements Initializable {
                                     new Task(Translation.getInstance().getTranslation(ic.getId()),
                                             ic.getId(),
                                             ic.getLevel()
-                                    ).setResultType(ic.getValueClass().orElse(null)), null, true))
+                                    ), null, true))
                             .collect(Collectors.toList())
             ));
         }
@@ -351,8 +351,9 @@ public class PrimaryViewModel implements Initializable {
                             .map(ic -> new CheckBoxTreeItem<Task>(
                                     new Task(Translation.getInstance().getTranslation(ic.getId()),
                                             ic.getId(),
-                                            ic.getLevel()
-                                    ).setIsBeta(ic.getIsBeta()).setResultType(ic.getValueClass().orElse(null)), null, true))
+                                            ic.getLevel(),
+                                            ic.getIsBeta()
+                                    ), null, true))
                             .collect(Collectors.toList())
             ));
             languageSpecificTaskCheckBoxItems.addAll(FXCollections.observableArrayList(
@@ -361,7 +362,7 @@ public class PrimaryViewModel implements Initializable {
                                     new Task(Translation.getInstance().getTranslation(ic.getId()),
                                             ic.getId(),
                                             ic.getLevel()
-                                    ).setResultType(ic.getValueClass().orElse(null)), null, true))
+                                    ), null, true))
                             .collect(Collectors.toList())
             ));
         }

--- a/src/main/java/software/latic/item/EnglishGeneralItemCharacteristics.java
+++ b/src/main/java/software/latic/item/EnglishGeneralItemCharacteristics.java
@@ -2,8 +2,6 @@ package software.latic.item;
 
 import software.latic.task.TaskLevel;
 
-import java.util.Optional;
-
 public enum EnglishGeneralItemCharacteristics implements ItemCharacteristics {
     FLESCH_INDEX( "fleschIndexEnglish", TaskLevel.TEXT_READABILITY),
     FLESCH_INDEX_LEVEL( "fleschIndexEnglishLevel", TaskLevel.TEXT_READABILITY),
@@ -37,25 +35,15 @@ public enum EnglishGeneralItemCharacteristics implements ItemCharacteristics {
 
     public boolean getIsBeta() {return isBeta;}
 
-    private final Class<?> valueClass;
-
-    @Override
-    public Optional<Class<?>> getValueClass() {
-        return Optional.ofNullable(valueClass);
-    }
-
-    EnglishGeneralItemCharacteristics(String id, TaskLevel level, boolean isBeta, Class<?> valueClass) {
+    EnglishGeneralItemCharacteristics(String id, TaskLevel level, boolean isBeta) {
         this.id = id;
         this.level = level;
         this.isBeta = isBeta;
-        this.valueClass = valueClass;
-    }
-
-    EnglishGeneralItemCharacteristics(String id, TaskLevel level, boolean isBeta) {
-        this( id, level, isBeta, null);
     }
 
     EnglishGeneralItemCharacteristics(String id, TaskLevel level) {
-        this( id, level, false);
+        this.id = id;
+        this.level = level;
+        this.isBeta = false;
     }
 }

--- a/src/main/java/software/latic/item/EnglishItemCharacteristics.java
+++ b/src/main/java/software/latic/item/EnglishItemCharacteristics.java
@@ -2,8 +2,6 @@ package software.latic.item;
 
 import software.latic.task.TaskLevel;
 
-import java.util.Optional;
-
 public enum EnglishItemCharacteristics implements ItemCharacteristics {
     CONJUNCTIONS("conjunctions", TaskLevel.WORD_CLASS),
     EXISTENTIAL_THERE("existentialThere", TaskLevel.WORD_CLASS),
@@ -25,26 +23,15 @@ public enum EnglishItemCharacteristics implements ItemCharacteristics {
     private final TaskLevel level;
 
     public TaskLevel getLevel() { return level; }
-    
-    private final Class<?> valueClass;
-    
-    @Override
-    public Optional<Class<?>> getValueClass() {
-        return Optional.ofNullable(valueClass);
-    }
-
-    EnglishItemCharacteristics(String id, TaskLevel level, Class<?> valueClass) {
-        this.id = id;
-        this.level = level;
-        this.valueClass = valueClass;
-    }
 
     EnglishItemCharacteristics(String id, TaskLevel level) {
-        this(id, level, null);
+        this.id = id;
+        this.level = level;
     }
 
     EnglishItemCharacteristics(String id) {
-        this(id, TaskLevel.WORD);
+        this.id = id;
+        this.level = TaskLevel.WORD;
     }
 
 }

--- a/src/main/java/software/latic/item/GeneralItemCharacteristics.java
+++ b/src/main/java/software/latic/item/GeneralItemCharacteristics.java
@@ -2,8 +2,6 @@ package software.latic.item;
 
 import software.latic.task.TaskLevel;
 
-import java.util.Optional;
-
 public enum GeneralItemCharacteristics implements ItemCharacteristics {
 
     WORD_COUNT("wordCount", TaskLevel.TEXT),
@@ -27,22 +25,9 @@ public enum GeneralItemCharacteristics implements ItemCharacteristics {
     public String getId() {
         return id;
     }
-    
-    private final Class<?> valueClass;
-    
-    @Override
-    public Optional<Class<?>> getValueClass() {
-        return Optional.ofNullable(valueClass);
-    }
 
-    GeneralItemCharacteristics(String id, TaskLevel level, Class<?> valueClass) {
+    GeneralItemCharacteristics(String id, TaskLevel level) {
         this.id = id;
         this.level = level;
-        this.valueClass = valueClass;
     }
-    
-    GeneralItemCharacteristics(String id, TaskLevel level) {
-        this(id, level, null);
-    }
-
 }

--- a/src/main/java/software/latic/item/GeneralLanguageItemCharacteristics.java
+++ b/src/main/java/software/latic/item/GeneralLanguageItemCharacteristics.java
@@ -2,8 +2,6 @@ package software.latic.item;
 
 import software.latic.task.TaskLevel;
 
-import java.util.Optional;
-
 public enum GeneralLanguageItemCharacteristics implements ItemCharacteristics {
 
 
@@ -33,25 +31,14 @@ public enum GeneralLanguageItemCharacteristics implements ItemCharacteristics {
     public String getId() {
         return id;
     }
-    
-    private final Class<?> valueClass;
-    
-    @Override
-    public Optional<Class<?>> getValueClass() {
-        return Optional.ofNullable(valueClass);
-    }
-
-    GeneralLanguageItemCharacteristics(String id, TaskLevel level, Class<?> valueClass) {
-        this.id = id;
-        this.level = level;
-        this.valueClass = valueClass;
-    }
 
     GeneralLanguageItemCharacteristics(String id, TaskLevel level) {
-        this(id, level, null);
+        this.id = id;
+        this.level = level;
     }
 
     GeneralLanguageItemCharacteristics(String id) {
-        this(id, TaskLevel.WORD);
+        this.id = id;
+        this.level = TaskLevel.WORD;
     }
 }

--- a/src/main/java/software/latic/item/GermanGeneralItemCharacteristics.java
+++ b/src/main/java/software/latic/item/GermanGeneralItemCharacteristics.java
@@ -2,8 +2,6 @@ package software.latic.item;
 
 import software.latic.task.TaskLevel;
 
-import java.util.Optional;
-
 public enum GermanGeneralItemCharacteristics implements ItemCharacteristics {
     FLESCH_INDEX( "fleschIndexGerman", TaskLevel.TEXT_READABILITY),
     FLESCH_INDEX_LEVEL( "fleschIndexGermanLevel", TaskLevel.TEXT_READABILITY),
@@ -31,26 +29,16 @@ public enum GermanGeneralItemCharacteristics implements ItemCharacteristics {
     public final boolean isBeta;
 
     public boolean getIsBeta() {return isBeta;}
-    
-    private final Class<?> valueClass;
-    
-    @Override
-    public Optional<Class<?>> getValueClass() {
-        return Optional.ofNullable(valueClass);
-    }
 
-    GermanGeneralItemCharacteristics(String id, TaskLevel level, boolean isBeta, Class<?> valueClass) {
+    GermanGeneralItemCharacteristics(String id, TaskLevel level, boolean isBeta) {
         this.id = id;
         this.level = level;
         this.isBeta = isBeta;
-        this.valueClass = valueClass;
-    }
-
-    GermanGeneralItemCharacteristics(String id, TaskLevel level, boolean isBeta) {
-        this(id, level, isBeta, null);
     }
 
     GermanGeneralItemCharacteristics(String id, TaskLevel level) {
-        this(id, level, false);
+        this.id = id;
+        this.level = level;
+        this.isBeta = false;
     }
 }

--- a/src/main/java/software/latic/item/GermanItemCharacteristics.java
+++ b/src/main/java/software/latic/item/GermanItemCharacteristics.java
@@ -2,8 +2,6 @@ package software.latic.item;
 
 import software.latic.task.TaskLevel;
 
-import java.util.Optional;
-
 public enum GermanItemCharacteristics implements ItemCharacteristics {
     ADPOSITIONS( "adpositions", TaskLevel.WORD_CLASS),
     COORDINATING_CONJUNCTIONS("coordinatingConjunctions", TaskLevel.WORD_CLASS),
@@ -20,25 +18,15 @@ public enum GermanItemCharacteristics implements ItemCharacteristics {
     public String getId() {
         return id;
     }
-    
-    private final Class<?> valueClass;
-    
-    @Override
-    public Optional<Class<?>> getValueClass() {
-        return Optional.ofNullable(valueClass);
-    }
 
-    GermanItemCharacteristics(String id, TaskLevel level, Class<?> valueClass) {
-        this.id = id;
-        this.level = level;
-        this.valueClass = valueClass;
-    }
 
     GermanItemCharacteristics(String id, TaskLevel level) {
-        this(id, level, null);
+        this.id = id;
+        this.level = level;
     }
 
     GermanItemCharacteristics(String id) {
-        this(id, TaskLevel.WORD);
+        this.id = id;
+        this.level = TaskLevel.WORD;
     }
 }

--- a/src/main/java/software/latic/item/ItemCharacteristics.java
+++ b/src/main/java/software/latic/item/ItemCharacteristics.java
@@ -2,11 +2,8 @@ package software.latic.item;
 
 import software.latic.task.TaskLevel;
 
-import java.util.Optional;
-
 public interface ItemCharacteristics {
 
     String getId();
     TaskLevel getLevel();
-    Optional<Class<?>> getValueClass();
 }

--- a/src/main/java/software/latic/item/SyllableItemCharacteristics.java
+++ b/src/main/java/software/latic/item/SyllableItemCharacteristics.java
@@ -2,8 +2,6 @@ package software.latic.item;
 
 import software.latic.task.TaskLevel;
 
-import java.util.Optional;
-
 public enum SyllableItemCharacteristics implements ItemCharacteristics {
 
     SYLLABLE_COUNT("syllableCount", TaskLevel.TEXT),
@@ -22,22 +20,10 @@ public enum SyllableItemCharacteristics implements ItemCharacteristics {
     public String getId() {
         return id;
     }
-    
-    private final Class<?> valueClass;
-    
-    @Override
-    public Optional<Class<?>> getValueClass() {
-        return Optional.ofNullable(valueClass);
-    }
 
-    SyllableItemCharacteristics(String id, TaskLevel level, Class<?> valueClass) {
+    SyllableItemCharacteristics(String id, TaskLevel level) {
         this.id = id;
         this.level = level;
-        this.valueClass = valueClass;
-    }
-    
-    SyllableItemCharacteristics(String id, TaskLevel level) {
-        this(id, level, null);
     }
 
 }

--- a/src/main/java/software/latic/item/TextInformationItemCharacteristics.java
+++ b/src/main/java/software/latic/item/TextInformationItemCharacteristics.java
@@ -2,11 +2,9 @@ package software.latic.item;
 
 import software.latic.task.TaskLevel;
 
-import java.util.Optional;
-
 public enum TextInformationItemCharacteristics implements ItemCharacteristics {
-    TEXT_AND_POS_TAGS("textAndPosTags", TaskLevel.TEXT, String.class),
-    PASSIVE_CONSTRUCTIONS_COUNT("passiveConstructionsCount", TaskLevel.TEXT, Integer.class),;
+    TEXT_AND_POS_TAGS("textAndPosTags", TaskLevel.TEXT),
+    PASSIVE_CONSTRUCTIONS_COUNT("passiveConstructionsCount", TaskLevel.TEXT);
 //    POS_TAGS_PER_SENTENCE("posTagsPerSentence", TaskLevel.TEXT);
 
 
@@ -17,25 +15,14 @@ public enum TextInformationItemCharacteristics implements ItemCharacteristics {
     private final TaskLevel level;
 
     public TaskLevel getLevel() { return level; }
-    
-    private final Class<?> valueClass;
-    
-    @Override
-    public Optional<Class<?>> getValueClass() {
-        return Optional.ofNullable(valueClass);
-    }
-
-    TextInformationItemCharacteristics(String id, TaskLevel level, Class<?> valueClass) {
-        this.id = id;
-        this.level = level;
-        this.valueClass = valueClass;
-    }
 
     TextInformationItemCharacteristics(String id, TaskLevel level) {
-        this(id, level, null);
+        this.id = id;
+        this.level = level;
     }
 
     TextInformationItemCharacteristics(String id) {
-        this(id, TaskLevel.WORD);
+        this.id = id;
+        this.level = TaskLevel.WORD;
     }
 }

--- a/src/main/java/software/latic/task/Task.java
+++ b/src/main/java/software/latic/task/Task.java
@@ -6,15 +6,12 @@ import javafx.beans.property.ReadOnlyStringProperty;
 import javafx.beans.property.ReadOnlyStringWrapper;
 import javafx.beans.property.SimpleBooleanProperty;
 
-import java.util.Optional;
-
 public class Task {
     private ReadOnlyStringWrapper name = new ReadOnlyStringWrapper();
     private ReadOnlyStringWrapper id = new ReadOnlyStringWrapper();
     private BooleanProperty selected = new SimpleBooleanProperty(false);
     private TaskLevel level;
     private boolean isBeta = false;
-    private Class<?>  resultType = null;
 
     public Task(TaskLevel taskLevel) {
         this.name.set(Translation.getInstance().getTranslation(taskLevel.name()));
@@ -28,6 +25,15 @@ public class Task {
         this.name.set(name);
         this.id.set(id);
         this.level = taskLevel;
+
+        this.selected.set(true);
+    }
+
+    public Task(String name, String id, TaskLevel taskLevel, boolean isBeta) {
+        this.name.set(name);
+        this.id.set(id);
+        this.level = taskLevel;
+        this.isBeta = isBeta;
 
         this.selected.set(true);
     }
@@ -74,14 +80,4 @@ public class Task {
     public boolean equals(Task task) {
         return this.id.equals(task.id);
     }
-
-    public Optional<Class<?>> getResultType() {
-        return Optional.ofNullable(resultType);
-    }
-
-    public Task setResultType(Class<?> resultType) {
-        this.resultType = resultType;
-        return this;
-    }
-
 }

--- a/src/main/java/software/latic/text_analyzer/NlpTextAnalyzer.java
+++ b/src/main/java/software/latic/text_analyzer/NlpTextAnalyzer.java
@@ -134,9 +134,7 @@ public class NlpTextAnalyzer extends BaseTextAnalyzer implements TextAnalyzer {
                     setterName = setterName.substring(0, 1).toUpperCase() + setterName.substring(1);
                     setterName = "set" + setterName;
 
-                    var resultClass = task.getResultType().orElse(String.class);
-
-                    setter = textItemData.getClass().getMethod(setterName, resultClass);
+                    setter = textItemData.getClass().getMethod(setterName, nlpMethod.getReturnType());
 
                     setter.invoke(textItemData, nlpMethod.invoke(this));
 


### PR DESCRIPTION
Revert resultTypes in ItemCharacteristics and Task to simplify logic

- Removed `getValueClass` method from `ItemCharacteristics` interface.
- Eliminated result type handling in `Task` and its associated logic.
- Refactored related enums and constructors accordingly.
- Updated UI and `NlpTextAnalyzer` to use return types directly from methods.