### PR TITLE
Add noun phrase analysis

### DIFF
--- a/src/main/java/software/latic/item/TextInformationItemCharacteristics.java
+++ b/src/main/java/software/latic/item/TextInformationItemCharacteristics.java
@@ -4,7 +4,8 @@ import software.latic.task.TaskLevel;
 
 public enum TextInformationItemCharacteristics implements ItemCharacteristics {
     TEXT_AND_POS_TAGS("textAndPosTags", TaskLevel.TEXT),
-    PASSIVE_CONSTRUCTIONS_COUNT("passiveConstructionsCount", TaskLevel.TEXT);
+    PASSIVE_CONSTRUCTIONS_COUNT("passiveConstructionsCount", TaskLevel.TEXT),
+    NOUN_PHRASES_COUNT("nounPhrasesCount", TaskLevel.TEXT);
 //    POS_TAGS_PER_SENTENCE("posTagsPerSentence", TaskLevel.TEXT);
 
 

--- a/src/main/java/software/latic/item/TextItemData.java
+++ b/src/main/java/software/latic/item/TextItemData.java
@@ -14,6 +14,7 @@ public abstract class TextItemData {
     final StringProperty text;
     StringProperty textAndPosTags;
     IntegerProperty passiveConstructionsCount;
+    IntegerProperty nounPhrasesCount;
     IntegerProperty wordCount;
     IntegerProperty sentenceCount;
     IntegerProperty syllableCount;
@@ -105,6 +106,7 @@ public abstract class TextItemData {
         this.text = new SimpleStringProperty(text);
         this.textAndPosTags = new SimpleStringProperty();
         this.passiveConstructionsCount = new SimpleIntegerProperty();
+        this.nounPhrasesCount = new SimpleIntegerProperty();
         this.wordCount = new SimpleIntegerProperty();
         this.sentenceCount = new SimpleIntegerProperty();
         this.syllableCount = new SimpleIntegerProperty();
@@ -127,6 +129,7 @@ public abstract class TextItemData {
         valueMap.put("text",getText());
         valueMap.put("textAndPosTags",getTextAndPosTags());
         valueMap.put("passiveConstructionsCount", String.valueOf(getPassiveConstructionsCount()));
+        valueMap.put("nounPhrasesCount", String.valueOf(getPassiveConstructionsCount()));
         valueMap.put("wordCount",String.valueOf(getWordCount()));
         valueMap.put("sentenceCount",String.valueOf(getSentenceCount()));
         valueMap.put("syllableCount",String.valueOf(getSyllableCount()));
@@ -333,7 +336,7 @@ public abstract class TextItemData {
         this.lixReadabilityLevel.set(lixReadabilityLevel);
     }
 
-    public Integer getPassiveConstructionsCount() {
+    public int getPassiveConstructionsCount() {
         return passiveConstructionsCount.get();
     }
 
@@ -341,7 +344,19 @@ public abstract class TextItemData {
         return passiveConstructionsCount;
     }
 
-    public void setPassiveConstructionsCount(Integer passiveConstructionsCount) {
+    public void setPassiveConstructionsCount(int passiveConstructionsCount) {
         this.passiveConstructionsCount.set(passiveConstructionsCount);
+    }
+
+    public int getNounPhrasesCount() {
+        return nounPhrasesCount.get();
+    }
+
+    public IntegerProperty nounPhrasesCountProperty() {
+        return nounPhrasesCount;
+    }
+
+    public void setNounPhrasesCount(int nounPhrasesCount) {
+        this.nounPhrasesCount.set(nounPhrasesCount);
     }
 }

--- a/src/main/java/software/latic/text_analyzer/NlpTextAnalyzer.java
+++ b/src/main/java/software/latic/text_analyzer/NlpTextAnalyzer.java
@@ -1,5 +1,6 @@
 package software.latic.text_analyzer;
 
+import software.latic.Logging;
 import software.latic.item.TextItemData;
 import software.latic.helper.TagMapper;
 import software.latic.linguistic_feature.LinguisticFeature;
@@ -11,8 +12,10 @@ import javafx.collections.ObservableList;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -43,14 +46,29 @@ public class NlpTextAnalyzer extends BaseTextAnalyzer implements TextAnalyzer {
         return sb.toString().trim();
     }
 
-    public Integer passiveConstructionsCount() {
+    public int nounPhrasesCount() {
+        AtomicLong count = new AtomicLong(0);
+        doc.sentences().forEach(sentence -> {
+            var tree = sentence.parse();
+            var childTrees = tree.getChildrenAsList();
+            Logger.getLogger("NlpTextAnalyzer").log(Level.INFO, tree.toString() );
+            count.addAndGet(countOccurrences(tree.toString(), "(NP"));
+        });
+        return count.intValue();
+    }
+
+    private int countOccurrences(String text, String substring) {
+        return (text.length() - text.replace(substring, "").length()) / substring.length();
+    }
+
+    public int passiveConstructionsCount() {
         AtomicInteger count = new AtomicInteger(0);
 
         doc.sentences().forEach(sentence -> {
             var labels = sentence.incomingDependencyLabels().stream()
                     .filter(Optional::isPresent)
                     .map(Optional::get)
-                    .collect(Collectors.toList());
+                    .toList();
 
             int pairsInSentence = (int) Math.min(
                     labels.stream().filter("nsubj:pass"::equals).count(),

--- a/src/main/java/software/latic/text_analyzer/NlpTextAnalyzer.java
+++ b/src/main/java/software/latic/text_analyzer/NlpTextAnalyzer.java
@@ -1,5 +1,6 @@
 package software.latic.text_analyzer;
 
+import edu.stanford.nlp.trees.Tree;
 import software.latic.Logging;
 import software.latic.item.TextItemData;
 import software.latic.helper.TagMapper;
@@ -10,10 +11,8 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
 import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
@@ -21,6 +20,14 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 public class NlpTextAnalyzer extends BaseTextAnalyzer implements TextAnalyzer {
+
+    final List<String> knownNounTags = List.of(
+            "NOUN",
+            "PROPN",
+            "MPN",
+            "NP",
+            "NNP"
+    );
 
     public static final NlpTextAnalyzer instance = new NlpTextAnalyzer();
 
@@ -48,17 +55,89 @@ public class NlpTextAnalyzer extends BaseTextAnalyzer implements TextAnalyzer {
 
     public int nounPhrasesCount() {
         AtomicLong count = new AtomicLong(0);
+        var nounPhrases = new ArrayList<String>();
+
         doc.sentences().forEach(sentence -> {
             var tree = sentence.parse();
-            var childTrees = tree.getChildrenAsList();
-            Logger.getLogger("NlpTextAnalyzer").log(Level.INFO, tree.toString() );
-            count.addAndGet(countOccurrences(tree.toString(), "(NP"));
+            Logger.getLogger("NlpTextAnalyzer").log(Level.INFO, tree.toString());
+
+            int additionalNPs = findNounSequences(tree, new HashSet<>(), nounPhrases);
+
+            count.addAndGet(additionalNPs);
         });
+        Logging.getInstance().debug("NlpTextAnalyzer", String.format("nounPhrases: %s", nounPhrases));
         return count.intValue();
     }
 
-    private int countOccurrences(String text, String substring) {
-        return (text.length() - text.replace(substring, "").length()) / substring.length();
+    private boolean labelIsNounPhrase(String labelValue) {
+        return labelValue.equalsIgnoreCase("NP")
+                || labelValue.equalsIgnoreCase("NP-TMP")
+                || labelValue.equalsIgnoreCase("WHNP")
+                || labelValue.equalsIgnoreCase("NPS");
+    }
+
+    private boolean isSimpleNounPhrase(Tree tree) {
+        return labelIsNounPhrase(tree.label().value()) && doesNotContainNP(tree);
+    }
+
+    private boolean isPPWithNoun(Tree tree) {
+        return tree.label().value().equalsIgnoreCase("PP")
+                && containsNoun(tree) && doesNotContainNP(tree);
+    }
+
+    private int findNounSequences(Tree tree, Set<Tree> counted, List<String> nounPhrases) {
+        int count = 0;
+
+        if (counted.contains(tree) || tree.depth() <= 1) {
+            return 0;
+        }
+
+        //If we find a NP -> NP SBAR sequence, we assume that SBAR does always describe the Subject in NP
+        if ((tree.label().value().equalsIgnoreCase("NP") && (containsOnlyNPAndSBAR(tree) || (containsNoun(tree) && containsPP(tree))))) {
+            count++;
+            nounPhrases.add(tree.toString());
+            counted.addAll(Arrays.asList(tree.children()));
+        }
+        else if (isPPWithNoun(tree) || isSimpleNounPhrase(tree)) {
+            count++;
+            nounPhrases.add(tree.toString());
+            counted.add(tree);
+        }
+
+        for (Tree child : tree.children()) {
+            count += findNounSequences(child, counted, nounPhrases);
+        }
+
+        return count;
+    }
+
+    private boolean containsOnlyNPAndSBAR(Tree tree) {
+        var hasSBAR = new AtomicBoolean(false) ;
+        var hasNP = new AtomicBoolean(false);
+
+        if (tree.children().length == 2) {
+            Arrays.stream(tree.children()).forEach(child -> {
+                if (child.value().equalsIgnoreCase("NP")){
+                    hasNP.set(true);
+                }
+                else if (child.value().equalsIgnoreCase("SBAR")){
+                    hasSBAR.set(true);
+                }
+            });
+        }
+        return hasSBAR.get() && hasNP.get();
+    }
+
+    private boolean containsNoun(Tree tree) {
+        return Arrays.stream(tree.children()).anyMatch(child -> knownNounTags.contains(child.label().value()));
+    }
+
+    private boolean containsPP(Tree tree) {
+        return Arrays.stream(tree.children()).anyMatch(child -> child.label().value().equalsIgnoreCase("PP"));
+    }
+
+    private boolean doesNotContainNP(Tree tree) {
+        return Arrays.stream(tree.children()).noneMatch(child -> Objects.equals(child.label().value(), "NP"));
     }
 
     public int passiveConstructionsCount() {

--- a/src/main/resources/software/latic/messages_de.properties
+++ b/src/main/resources/software/latic/messages_de.properties
@@ -30,6 +30,7 @@ lixReadabilityScore=LIX
 textAndPosTags=Annotierter Text / Annotiertes Item
 passiveConstructions=Passivkonstruktionen
 passiveConstructionsCount=Passivkonstruktionen
+nounPhrasesCount=Nominalphrasen
 posTagsPerSentence=Annotierte Sätze
 #General language tasks
 adjectives=Adjektive

--- a/src/main/resources/software/latic/messages_en.properties
+++ b/src/main/resources/software/latic/messages_en.properties
@@ -29,6 +29,7 @@ lixReadabilityScore=LIX
 textAndPosTags=Tagged text or item
 passiveConstructions=Passive constructions
 passiveConstructionsCount=Passive constructions
+nounPhrasesCount=Noun phrases
 posTagsPerSentence=Tagged sentences
 #General language tasks
 adjectives=Adjectives

--- a/src/test/java/software/latic/text_analyzer/NlpTextAnalyzerTest.java
+++ b/src/test/java/software/latic/text_analyzer/NlpTextAnalyzerTest.java
@@ -1,11 +1,41 @@
 package software.latic.text_analyzer;
 
+import edu.stanford.nlp.io.IOUtils;
 import edu.stanford.nlp.simple.Document;
 import org.junit.jupiter.api.Test;
+import software.latic.syllables.SyllableProvider;
+import software.latic.translation.Translation;
+
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class NlpTextAnalyzerTest {
+
+    NlpTextAnalyzer nlpTextAnalyzer;
+
+    void setDocument(String locale, String text) {
+        Properties props = new Properties();
+
+        if (locale.equalsIgnoreCase("de")) {
+            try {
+                props.load(IOUtils.readerFromString("StanfordCoreNLP-german.properties"));
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+
+            Translation.getInstance().setLocale(Locale.GERMAN);
+        } else {
+            Translation.getInstance().setLocale(Locale.ENGLISH);
+        }
+
+
+        Document doc = new Document(props, text);
+        nlpTextAnalyzer = NlpTextAnalyzer.getInstance();
+        nlpTextAnalyzer.setDoc(doc);
+    }
 
     @Test
     void givenDocumentWithPassiveVoice_whenPassiveConstructionsCalled_thenCorrectDependenciesReturned() {
@@ -23,6 +53,148 @@ class NlpTextAnalyzerTest {
         assertTrue(result.contains("nsubj:pass"), "Expected 'nsubj:pass' dependency for passive voice.");
         assertTrue(result.contains("aux:pass"), "Expected 'aux:pass' dependency for auxiliary passive.");
         assertTrue(result.contains("obl"), "Expected 'obl' dependency to indicate 'by the class'.");
+    }
+
+    @Test
+    void givenDocumentWithSimpleSentence_whenNounPhrasesCountCalled_thenCorrectCountReturned() {
+        // Arrange
+        String text = "The quick brown fox jumps over the lazy dog.";
+        Document doc = new Document(text);
+        NlpTextAnalyzer analyzer = NlpTextAnalyzer.getInstance();
+        analyzer.setDoc(doc);
+
+        // Act
+        int result = analyzer.nounPhrasesCount();
+
+        // Assert
+        assertEquals(2, result, "Expected 2 noun phrases in the sentence.");
+    }
+
+    @Test
+    void givenDocumentWithRepeatedPhrase_whenNounPhrasesCountCalled_thenCorrectCountReturned() {
+        // Arrange
+        String text = "The quick brown fox jumps over the quick brown fox. The quick brown fox jumps over the quick brown fox.";
+        Document doc = new Document(text);
+        NlpTextAnalyzer analyzer = NlpTextAnalyzer.getInstance();
+        analyzer.setDoc(doc);
+
+        // Act
+        int result = analyzer.nounPhrasesCount();
+
+        // Assert
+        assertEquals(4, result, String.format("Expected 2 noun phrases, but got %d in the sentence %s", result, text));
+    }
+
+    @Test
+    void givenDocumentWithEnglishSentence_whenNounPhrasesCountCalled_thenCorrectCountReturned() {
+        // Arrange
+        String[][] testCases = {
+                {"The dog barked loudly.", "1"},
+                {"She gave a gift to her brother.", "3"},
+                {"That small red book belongs to Emily.", "2"},
+                {"I saw a group of children playing outside.", "2"},
+                {"The man with the briefcase entered the room.", "2"},
+                {"A surprisingly large number of tourists arrived last year.", "2"},
+                {"The teacher who inspired me most retired last year.", "2"},
+                {"Many of the students in the back row were sleeping.", "1"},
+                {"Her decision to quit her job so suddenly shocked everyone.", "3"},
+                {"The man with the hat from the old shop is here.", "1"},
+        };
+
+        for (String[] testCase : testCases) {
+            String text = testCase[0];
+            int expected = Integer.parseInt(testCase[1]);
+
+            Document doc = new Document(text);
+            setDocument("en", text);
+
+            // Act
+            int result = nlpTextAnalyzer.nounPhrasesCount();
+
+            // Assert
+            assertEquals(expected, result, "Expected " + expected + " noun phrases in: " + text);
+        }
+    }
+
+    @Test
+    void givenDocumentWithGermanSentence_whenNounPhrasesCountCalled_thenCorrectCountReturned() {
+        // Arrange
+        String[][] testCases = {
+                {"Der schnelle braune Fuchs springt über den faulen Hund.", "2"},
+                {"Schnelle braune Füche springen über faule Hunde.", "2"},
+                {"Der Mann geht in das Haus.", "2"},
+                {"Die schöne Blume blüht im Garten.", "2"},
+                {"Viele Schüler arbeiten mit großer Konzentration.", "2"},
+                {"Blumen blühen in großen Gärten.", "1"},
+                {"Blumen blühen in Hamburg.", "1"},
+                {"In der Elbchaussee wohnt ein Schnösel.", "2"},
+                {"Auf St. Pauli brennt noch Licht.", "1"},
+                {"Seit gestern bin ich 58.", "0"},
+                {"Viele der Schüler aus der letzten Reihe haben nichts verstanden.", "1"},
+                {"Liegt der Zettel in deiner neuen Mappe oder in deiner Alten?", "3"},
+                {"Ein Glas Wasser steht auf dem Tisch neben dem Buch.", "3"},
+                {"Der braune Bär macht seinen Winterschalf.", "2"},
+                {"Ich traf eine Gruppe von Touristen am Bahnhof.", "2"}
+        };
+
+        for (String[] testCase : testCases) {
+            String text = testCase[0];
+            int expected = Integer.parseInt(testCase[1]);
+
+            Document doc = new Document(text);
+            setDocument("de", text);
+
+            // Act
+            int result = nlpTextAnalyzer.nounPhrasesCount();
+
+            // Assert
+            assertEquals(expected, result, "Expected " + expected + " noun phrases in: " + text);
+        }
+    }
+
+    @Test
+    void givenEmptyDocument_whenNounPhrasesCountCalled_thenZeroCountReturned() {
+        // Arrange
+        String text = "";
+        Document doc = new Document(text);
+        NlpTextAnalyzer analyzer = NlpTextAnalyzer.getInstance();
+        analyzer.setDoc(doc);
+
+        // Act
+        int result = analyzer.nounPhrasesCount();
+
+        // Assert
+        assertEquals(0, result, "Expected 0 noun phrases in an empty document.");
+    }
+
+    @Test
+    void givenDocumentWithMultipleSentences_whenNounPhrasesCountCalled_thenCorrectCountReturned() {
+        // Arrange
+        String text = "The big apple is famous. New York is bustling. The nice house is green.";
+        Document doc = new Document(text);
+        NlpTextAnalyzer analyzer = NlpTextAnalyzer.getInstance();
+        analyzer.setDoc(doc);
+
+        // Act
+        int result = analyzer.nounPhrasesCount();
+
+        // Assert
+        assertEquals(3, result, "Expected 3 noun phrases across two sentences.");
+    }
+
+    @Test
+    void givenDocumentWithComplexStructure_whenNounPhrasesCountCalled_thenCorrectCountReturned() {
+        // Arrange
+        String text = "The teacher, who was highly respected, gave the students an insightful lecture.";
+        Document doc = new Document(text);
+        NlpTextAnalyzer analyzer = NlpTextAnalyzer.getInstance();
+        analyzer.setDoc(doc);
+
+        // Act
+        int result = analyzer.nounPhrasesCount();
+
+        // Assert
+        assertEquals(4, result, "Expected 4 noun phrases in the complex sentence.");
     }
 
     @Test


### PR DESCRIPTION
- Introduced `nounPhrasesCount` property in `TextItemData`.
- Added `NOUN_PHRASES_COUNT` to `TextInformationItemCharacteristics`.
- Implemented `nounPhrasesCount` method in `NlpTextAnalyzer` to identify noun phrases using linguistic tree analysis.
- Updated test cases in `NlpTextAnalyzerTest` to validate noun phrase analysis.
- Enhanced property files to include translations for noun phrase analysis identifiers.